### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,6 @@ rock_library(pocolog_cpp
         Write.cpp 
         Index.cpp 
         InputDataStream.cpp
-#         OutputDataStream.cpp
         StreamDescription.cpp 
         Stream.cpp 
         LogFile.cpp 

--- a/src/Format.hpp
+++ b/src/Format.hpp
@@ -35,7 +35,7 @@
 #define POCOLOG_CPP_FORMAT_H
 
 #include <stdint.h>
-#include <base/time.h>
+#include <base/Time.hpp>
 
 /**
  * Log files are made of blocks. Each block begins with a common block header. 

--- a/src/MultiFileIndex.cpp
+++ b/src/MultiFileIndex.cpp
@@ -29,16 +29,16 @@ bool MultiFileIndex::createIndex(const std::vector< std::string >& fileNames)
         std::cout << "Loading logfile " << *it << std::endl;
         LogFile *curLogfile = new LogFile(*it);
         
-        for(std::vector<Stream *>::const_iterator it = curLogfile->getStreams().begin(); it != curLogfile->getStreams().end(); it++)
+        for(std::vector<Stream *>::const_iterator jt = curLogfile->getStreams().begin(); jt != curLogfile->getStreams().end(); jt++)
         {
-            if((*it)->getSize())
+            if((*jt)->getSize())
             {
-                globalSampleCount += (*it)->getSize();
+                globalSampleCount += (*jt)->getSize();
                 
                 IndexEntry entry;
-                entry.stream = *it;
+                entry.stream = *jt;
                 
-                streamMap.insert(std::make_pair((*it)->getFistSampleTime(), entry));
+                streamMap.insert(std::make_pair((*jt)->getFistSampleTime(), entry));
             }
         }
         

--- a/src/StreamDescription.cpp
+++ b/src/StreamDescription.cpp
@@ -52,18 +52,18 @@ StreamDescription::StreamDescription(const std::string &fileName, pocolog_cpp::F
             
             std::streampos curPos = fileStream.tellg();
             
-            if(curPos - startPos < blockSize)
+            if(curPos - startPos < (int)blockSize)
             {
                 m_typeDescription = readString(fileStream);
 //                 std::cout << "Found stream description : " << m_typeDescription << std::endl;
             }
-            if(curPos - startPos < blockSize)
+            if(curPos - startPos < (int)blockSize)
             {
                 m_metadata = readString(fileStream);
             }
             
             curPos = fileStream.tellg();
-            if(curPos - startPos != blockSize)
+            if(curPos - startPos != (int)blockSize)
             {
                 std::streampos diff = curPos - startPos;
 //                 std::cout << "Start of Stream Declaration " << startPos << " diff " << diff << " expected size " << blockSize << std::endl;

--- a/src/StreamDescription.cpp
+++ b/src/StreamDescription.cpp
@@ -65,7 +65,7 @@ StreamDescription::StreamDescription(const std::string &fileName, pocolog_cpp::F
             curPos = fileStream.tellg();
             if(curPos - startPos != (int)blockSize)
             {
-                std::streampos diff = curPos - startPos;
+//                 std::streampos diff = curPos - startPos;
 //                 std::cout << "Start of Stream Declaration " << startPos << " diff " << diff << " expected size " << blockSize << std::endl;
 
 //                 uint32_t stringSize = blockSize - diff;

--- a/src/Write.cpp
+++ b/src/Write.cpp
@@ -67,7 +67,7 @@ namespace pocolog_cpp
     int Output::newStreamIndex()
     { return m_stream_idx++; }
 
-    void Output::writeStreamDeclaration(int stream_index, StreamType type,
+    void Output::writeStreamDeclaration(uint16_t stream_index, StreamType type,
             std::string const& name, std::string const& type_name,
             std::string const& type_def,
             std::vector<StreamMetadata> const& metadata)
@@ -81,7 +81,7 @@ namespace pocolog_cpp
             metadata_yaml = yaml_io.str();
         }
 
-        long payload_size = 1 + 4 + name.size() + 4 + type_name.size()
+        uint32_t payload_size = 1 + 4 + name.size() + 4 + type_name.size()
             + 4 + type_def.size()
             + 4 + metadata_yaml.size();
 
@@ -98,7 +98,7 @@ namespace pocolog_cpp
         }
     }
 
-    void Output::writeSampleHeader(int stream_index, base::Time const& realtime, base::Time const& logical, size_t payload_size)
+    void Output::writeSampleHeader(uint16_t stream_index, base::Time const& realtime, base::Time const& logical, uint32_t payload_size)
     {
         BlockHeader block_header = { DataBlockType, 0xFF, stream_index, SAMPLE_HEADER_SIZE + payload_size };
         *this << block_header;
@@ -107,7 +107,7 @@ namespace pocolog_cpp
         *this << sample_header;
     }
 
-    void Output::writeSample(int stream_index, base::Time const& realtime, base::Time const& logical, void* payload_data, size_t payload_size)
+    void Output::writeSample(uint16_t stream_index, base::Time const& realtime, base::Time const& logical, void* payload_data, uint32_t payload_size)
     {
         writeSampleHeader(stream_index, realtime, logical, payload_size);
         m_stream.write(reinterpret_cast<const char*>(payload_data), payload_size);
@@ -162,15 +162,15 @@ namespace pocolog_cpp
     std::ostream& StreamWriter::getStream()
     { return m_file.getStream(); }
 
-    bool StreamWriter::writeSampleHeader(const base::Time& timestamp, size_t size)
+    bool StreamWriter::writeSampleHeader(const base::Time& timestamp, uint32_t payload_size)
     {
         if (!m_last.isNull() && !m_sampling.isNull() && (timestamp - m_last) < m_sampling)
             return false;
 
-        if (size == 0)
-            size = m_type_size;
+        if (payload_size == 0)
+            payload_size = m_type_size;
 
-        m_file.writeSampleHeader(m_stream_idx, base::Time::now(), timestamp, size);
+        m_file.writeSampleHeader(m_stream_idx, base::Time::now(), timestamp, payload_size);
         m_last = timestamp;
         return true;
     }

--- a/src/Write.cpp
+++ b/src/Write.cpp
@@ -64,7 +64,7 @@ namespace pocolog_cpp
         writePrologue(stream);
     }
 
-    int Output::newStreamIndex()
+    uint16_t Output::newStreamIndex()
     { return m_stream_idx++; }
 
     void Output::writeStreamDeclaration(uint16_t stream_index, StreamType type,

--- a/src/Write.hpp
+++ b/src/Write.hpp
@@ -52,7 +52,7 @@ namespace pocolog_cpp
         static const size_t nstream = static_cast<size_t>(-1);
 
         std::ostream& m_stream;
-        int m_stream_idx;
+        uint16_t m_stream_idx;
 
     private:
         template<class T>
@@ -68,7 +68,7 @@ namespace pocolog_cpp
 
         std::ostream& getStream();
 
-        int newStreamIndex();
+        uint16_t newStreamIndex();
 
         void writeStreamDeclaration(uint16_t stream_index, StreamType type,
                 std::string const& name, std::string const& type_name,
@@ -167,8 +167,9 @@ namespace pocolog_cpp
         std::string const m_type_name;
         std::string const m_type_def;
         std::vector<StreamMetadata> m_metadata;
-        int const m_stream_idx;
-        size_t const m_type_size;
+        // same types as in "struct BlockHeader"
+        uint16_t const m_stream_idx;
+        uint32_t const m_type_size;
         base::Time m_sampling;
         base::Time m_last;
 

--- a/src/Write.hpp
+++ b/src/Write.hpp
@@ -49,7 +49,6 @@ namespace pocolog_cpp
     class Output
     {
         template<class T> friend Output& operator << (Output& output, const T& value);
-        static const size_t nstream = static_cast<size_t>(-1);
 
         std::ostream& m_stream;
         uint16_t m_stream_idx;

--- a/src/Write.hpp
+++ b/src/Write.hpp
@@ -70,12 +70,12 @@ namespace pocolog_cpp
 
         int newStreamIndex();
 
-        void writeStreamDeclaration(int stream_index, StreamType type,
+        void writeStreamDeclaration(uint16_t stream_index, StreamType type,
                 std::string const& name, std::string const& type_name,
                 std::string const& type_def,
                 std::vector<StreamMetadata> const& metadata);
-        void writeSampleHeader(int stream_index, base::Time const& realtime, base::Time const& logical, size_t size);
-        void writeSample(int stream_index, base::Time const& realtime, base::Time const& logical, void* payload_data, size_t payload_size);
+        void writeSampleHeader(uint16_t stream_index, base::Time const& realtime, base::Time const& logical, uint32_t payload_size);
+        void writeSample(uint16_t stream_index, base::Time const& realtime, base::Time const& logical, void* payload_data, uint32_t payload_size);
     };
 
     namespace details
@@ -207,7 +207,7 @@ namespace pocolog_cpp
          */
         void setSampling(base::Time const& period);
 
-        bool writeSampleHeader(const base::Time& timestamp, size_t size);
+        bool writeSampleHeader(const base::Time& timestamp, uint32_t payload_size);
 
         std::ostream& getStream();
     };

--- a/src/indexer.cpp
+++ b/src/indexer.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
         
         std::cout << "Stream size is " << dataStream->getSize() << std::endl;
         
-        for(int i = 0; i < dataStream->getSize(); i++)
+        for(size_t i = 0; i < dataStream->getSize(); i++)
         {
             base::samples::Joints joints;
             if(!dataStream->getSample<base::samples::Joints>(joints, i))

--- a/src/speedTest.cpp
+++ b/src/speedTest.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
 
         
         
-        for(int i = 0 ; i < bufferSize; i++)
+        for(size_t i = 0 ; i < bufferSize; i++)
         {
             char t = 'a';
             file1.write(&t, sizeof(char));
@@ -39,13 +39,13 @@ int main(int argc, char **argv)
             return 0;
         }
         
-        for(int i = 0 ; i < bufferSize; i++)
+        for(size_t i = 0 ; i < bufferSize; i++)
         {
             char t = 'a';
             readBuffer[i] = t;
         }
         
-        int written = 0;
+        size_t written = 0;
         
         std::cout << "Fd is " << fd <<std::endl;
         


### PR DESCRIPTION
There are some more controversial commits hidden here. Have a longer stare at 80be45043c94c95dc198a01403b66446f6ceec26 200d8c6d2947de6cc7a20ac2c9e5bc8f50eb78a9 and e7148817c2b565906d553b6595a678170116ac09.

Besides, see this [issue](https://github.com/rock-core/tools-pocolog_cpp/issues/2) which is more or less related to 80be45043c94c95dc198a01403b66446f6ceec26.