### PR TITLE
Removed streaming operator function that makes build fail with clang in C++11 mode

### DIFF
--- a/src/Write.hpp
+++ b/src/Write.hpp
@@ -77,21 +77,8 @@ namespace pocolog_cpp
         void writeSample(uint16_t stream_index, base::Time const& realtime, base::Time const& logical, void* payload_data, uint32_t payload_size);
     };
 
-    namespace details
-    {
-        template <bool value> struct static_check;
-        template<> struct static_check<true> {};
-    }
-
     /** Writes the file prologue */
     void writePrologue(std::ostream& stream);
-
-    template<class T>
-    Output& operator << (Output& output, const T& value)
-    {
-        details::static_check<false> test;
-        return output;
-    }
 
     template<>
     inline Output& operator << (Output& output, const uint8_t& value)


### PR DESCRIPTION
This function causes clang with cxx11 features to build failures
It seems that this compiler setup evaluates the funtion at compiletime
of this lib. Nevertheless the whole function is not needed because
it postprones the error to here. Otherwise the user would get a warning
that his required specialization of the streaming is not implemented.