### PR TITLE
fix compilation on C++11 and clang

### DIFF
--- a/src/Write.hpp
+++ b/src/Write.hpp
@@ -79,8 +79,7 @@ namespace pocolog_cpp
 
     namespace details
     {
-        template <bool value> struct static_check;
-        template<> struct static_check<true> {};
+        template <typename T> struct static_failure;
     }
 
     /** Writes the file prologue */
@@ -89,7 +88,7 @@ namespace pocolog_cpp
     template<class T>
     Output& operator << (Output& output, const T& value)
     {
-        details::static_check<false> test;
+        details::static_failure<T> IF_YOU_HAVE_AN_ERROR_HERE_YOU_USED_THE_STREAM_OPERATOR_WITH_AN_INVALID_TYPE;
         return output;
     }
 


### PR DESCRIPTION
This supersedes #4, fixing the problem without removing the feature of having a compilation error on both gcc and clang.